### PR TITLE
Add optional serde serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "cc"
@@ -583,6 +583,8 @@ dependencies = [
  "gpiosim",
  "human-sort",
  "nohash-hasher",
+ "serde",
+ "serde_derive",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -680,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -994,6 +996,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-segmentation"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,6 +23,8 @@ futures = {version = "0.3", optional = true}
 gpiocdev-uapi = {version = "0.3", path = "../uapi", default-features = false}
 human-sort = "0.2"
 nohash-hasher = "0.2"
+serde = {version = "1.0", optional = true}
+serde_derive = {version = "1.0", optional = true}
 thiserror = "1.0"
 tokio = {version = "1.21", features = ["net"], optional = true}
 tokio-stream = {version = "0.1.11", optional = true}
@@ -37,6 +39,7 @@ tokio = {version = "1.21", features = ["macros", "rt", "time"]}
 async_io = ["async-io", "futures"]
 async_tokio = ["tokio-stream", "tokio/net", "futures"]
 default = ["uapi_v2"]
+serde = ["dep:serde", "serde_derive"]
 uapi_v1 = ["gpiocdev-uapi/uapi_v1"]
 uapi_v2 = ["gpiocdev-uapi/uapi_v2"]
 

--- a/lib/src/chip.rs
+++ b/lib/src/chip.rs
@@ -12,6 +12,8 @@ use gpiocdev_uapi::v1 as uapi;
 use gpiocdev_uapi::v2 as uapi;
 #[cfg(all(feature = "uapi_v1", feature = "uapi_v2"))]
 use gpiocdev_uapi::{v1, v2};
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
 #[cfg(all(feature = "uapi_v1", feature = "uapi_v2"))]
 use std::cell::RefCell;
 use std::fmt;
@@ -373,6 +375,7 @@ impl AsRawFd for Chip {
 
 /// The publicly available information for a GPIO chip.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Info {
     /// The system name for the chip, such as "*gpiochip0*".
     pub name: String,

--- a/lib/src/line.rs
+++ b/lib/src/line.rs
@@ -11,11 +11,14 @@ use gpiocdev_uapi::{v2, v2 as uapi};
 use nohash_hasher::IntMap;
 use std::collections::hash_map::Iter;
 use std::time::Duration;
+#[cfg(feature = "serde")]
+use serde_derive::{Deserialize, Serialize};
 
 /// The configuration settings for a single line.
 ///
 // Note it does not contain the offset to allow it to be applied to multiple lines.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Config {
     /// The direction setting for the line.
     pub direction: Option<Direction>,
@@ -177,6 +180,7 @@ impl From<&Config> for v1::HandleRequestFlags {
 
 /// The publicly available information for a line.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct Info {
     /// The line offset on the GPIO chip.
     pub offset: Offset,
@@ -204,21 +208,25 @@ pub struct Info {
     pub direction: Direction,
 
     /// The bias state of the line.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub bias: Option<Bias>,
 
     /// The drive applied to output lines.
     ///
     /// Only relevant for output lines.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub drive: Option<Drive>,
 
     /// The edge detection state for the line.
     ///
     /// Only relevant for input lines.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub edge_detection: Option<EdgeDetection>,
 
     /// The source clock for edge event timestamps.
     ///
     /// Only relevant for input lines with edge detection.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub event_clock: Option<EventClock>,
 
     /// The debounce period.
@@ -226,6 +234,7 @@ pub struct Info {
     /// Only relevant for input lines with edge detection.
     ///
     /// None or a zero value means no debounce.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub debounce_period: Option<Duration>,
 }
 
@@ -296,6 +305,7 @@ pub type Offsets = Vec<Offset>;
 /// | **Active-Low**  | Active | Inactive |
 ///
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Value {
     /// The line is inactive.
     Inactive,
@@ -363,6 +373,7 @@ impl From<u8> for Value {
 ///
 /// Lines are identified by their offset.
 #[derive(Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Values(IntMap<Offset, Value>);
 impl Values {
     /// overlays the values from src over the values in the dst.
@@ -476,6 +487,7 @@ impl Values {
 
 /// The direction of a line.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Direction {
     /// The line is an input.
     Input,
@@ -509,6 +521,7 @@ impl From<v2::LineFlags> for Direction {
 
 /// The bias settings for a line.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Bias {
     /// The line has pull-up enabled.
     PullUp,
@@ -557,6 +570,7 @@ impl TryFrom<v2::LineFlags> for Bias {
 
 /// The drive policy settings for an output line.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Drive {
     /// The line is driven when both active and inactive.
     ///
@@ -611,6 +625,7 @@ impl TryFrom<v2::LineFlags> for Drive {
 
 /// The edge detection options for an input line.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EdgeDetection {
     /// Edge detection is only enabled on rising edges.
     ///
@@ -645,6 +660,7 @@ impl TryFrom<v2::LineFlags> for EdgeDetection {
 
 /// The available clock sources for [`EdgeEvent`] timestamps.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EventClock {
     /// The **CLOCK_MONOTONIC** is used as the source for edge event timestamps.
     ///
@@ -682,6 +698,7 @@ impl From<v2::LineFlags> for EventClock {
 ///
 /// ABI v1 does not provide the seqno nor line_seqno fields.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(rename_all = "camelCase"))]
 pub struct EdgeEvent {
     /// The best estimate of time of event occurrence, in nanoseconds.
     ///
@@ -736,6 +753,7 @@ impl From<&v2::LineEdgeEvent> for EdgeEvent {
 
 /// The cause of an [`EdgeEvent`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EdgeKind {
     /// Indicates the line transitioned from inactive to active.
     Rising = 1,
@@ -754,6 +772,7 @@ impl From<uapi::LineEdgeEventKind> for EdgeKind {
 
 /// The details of a change to the [`Info`] for a line.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InfoChangeEvent {
     /// The updated line info.
     pub info: Info,
@@ -789,6 +808,7 @@ impl From<&v2::LineInfoChangeEvent> for InfoChangeEvent {
 
 /// The cause of a [`InfoChangeEvent`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum InfoChangeKind {
     /// Line has been requested.
     Requested = 1,


### PR DESCRIPTION
This adds optional serde support to serialize info and event structs. This is quite helpful if you need to communicate GPIO features with other nodes in the network, especially if they're written in a different language.

It lets you easily serialize info into any format supported by _serde_, including JSON, like this:
```
{
  "chip": {
    "name": "gpiochip0",
    "label": "INT3450:00",
    "numLines": 32
  },
  "lines": [
    {
      "offset": 0,
      "name": "",
      "consumer": "",
      "used": false,
      "activeLow": false,
      "direction": "Input"
    },
    {
      "offset": 1,
      "name": "",
      "consumer": "",
      "used": false,
      "activeLow": false,
      "direction": "Input"
    },
    {
      "offset": 2,
      "name": "",
      "consumer": "",
      "used": false,
      "activeLow": false,
      "direction": "Input"
    },
    ...
  ]
}
```