### PR TITLE
Implement `AsRef<Request>` for `Request`.

### DIFF
--- a/lib/src/request.rs
+++ b/lib/src/request.rs
@@ -676,6 +676,13 @@ impl AsRawFd for Request {
     }
 }
 
+impl AsRef<Request> for Request {
+    #[inline]
+    fn as_ref(&self) -> &Request {
+        &self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Request;


### PR DESCRIPTION
This helps avoid `cfg` attributes since `.as_ref()` will work on `Request` as well as `AsyncRequest`.